### PR TITLE
Document threat model and security baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ The project is considered successful when all of the following measurable condit
 5. **Full test coverage for critical paths** – Parsing, apply, and configuration exchange code paths have 100% test coverage.
 6. **Distribution packages** – Packages are produced for Debian/Ubuntu and RHEL/Fedora.
 
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for the threat model and security baseline.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Threat Model
+
+An attacker is assumed to have network access and possibly a low-privileged account. Potential attacks include:
+
+- Injection of shell arguments through the web UI.
+- Abuse of privileged operations.
+- Theft of private keys.
+- Tampering with configuration files.
+- Exfiltration of configuration exchange bundles.
+
+## Security Baseline Controls
+
+To mitigate these threats, the project adopts the following baseline controls:
+
+- Principle of least privilege for all components.
+- Polkit-gated backend exposing a very small, explicit API.
+- Strict input validation and canonicalization.
+- No arbitrary command execution.
+- Content-Security-Policy forbidding inline scripts.
+- Zero private keys retained in frontend memory.
+- `umask 077` for all sensitive file operations.
+- Atomic writes with rollback on failure.
+- Audit logs for privileged actions.
+- Rate-limited, authenticated import of configuration exchange bundles.
+


### PR DESCRIPTION
## Summary
- add SECURITY.md detailing threat model and baseline controls
- link to security policy from the README

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_b_68966d10f3dc8330ab9380a3e5ea480f