### PR TITLE
Register WireGuard Cockpit plugin

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="pf-v5-theme-light">
   <head>
     <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self';img-src 'self' data:;font-src 'self';object-src 'none';" />
+    <meta name="color-scheme" content="light dark" />
     <title>Cockpit WireGuard</title>
   </head>
   <body>

--- a/ui/manifest.json
+++ b/ui/manifest.json
@@ -1,6 +1,12 @@
 {
-  "name": "cockpit-wg",
-  "version": "0.0.1",
-  "apiVersion": 1,
-  "main": "index.html"
+  "version": 1,
+  "content-security-policy": "default-src 'self';img-src 'self' data:;font-src 'self';object-src 'none';",
+  "tools": {
+    "wireguard": {
+      "label": "WireGuard",
+      "path": "index.html",
+      "keywords": ["wireguard", "vpn", "wg"]
+    }
+  }
 }
+

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import '@patternfly/react-core/dist/styles/base.css';
+import './preloadFonts';
+import './theme';
 import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(

--- a/ui/src/preloadFonts.ts
+++ b/ui/src/preloadFonts.ts
@@ -1,0 +1,27 @@
+import redHatText from '@patternfly/react-core/dist/styles/assets/fonts/RedHatText/RedHatTextVF.woff2';
+import redHatTextItalic from '@patternfly/react-core/dist/styles/assets/fonts/RedHatText/RedHatTextVF-Italic.woff2';
+import redHatDisplay from '@patternfly/react-core/dist/styles/assets/fonts/RedHatDisplay/RedHatDisplayVF.woff2';
+import redHatDisplayItalic from '@patternfly/react-core/dist/styles/assets/fonts/RedHatDisplay/RedHatDisplayVF-Italic.woff2';
+import redHatMono from '@patternfly/react-core/dist/styles/assets/fonts/RedHatMono/RedHatMonoVF.woff2';
+import redHatMonoItalic from '@patternfly/react-core/dist/styles/assets/fonts/RedHatMono/RedHatMonoVF-Italic.woff2';
+import pfIcon from '@patternfly/react-core/dist/styles/assets/pficon/pf-v5-pficon.woff2';
+
+const fonts = [
+  redHatText,
+  redHatTextItalic,
+  redHatDisplay,
+  redHatDisplayItalic,
+  redHatMono,
+  redHatMonoItalic,
+  pfIcon
+];
+
+for (const href of fonts) {
+  const link = document.createElement('link');
+  link.rel = 'preload';
+  link.as = 'font';
+  link.href = href;
+  link.type = 'font/woff2';
+  link.crossOrigin = '';
+  document.head.appendChild(link);
+}

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -1,0 +1,9 @@
+const setTheme = (isDark: boolean) => {
+  const root = document.documentElement;
+  root.classList.remove('pf-v5-theme-light', 'pf-v5-theme-dark');
+  root.classList.add(isDark ? 'pf-v5-theme-dark' : 'pf-v5-theme-light');
+};
+
+const mq = window.matchMedia('(prefers-color-scheme: dark)');
+setTheme(mq.matches);
+mq.addEventListener('change', (e) => setTheme(e.matches));

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  base: './',
   plugins: [react()],
   build: {
     outDir: 'dist'


### PR DESCRIPTION
## Summary
- add Cockpit manifest for WireGuard tool page
- bootstrap React app with strict CSP and relative assets
- preload PatternFly fonts and switch theme based on system preference

## Testing
- `npm --prefix ui run build`
- `make dist`


------
https://chatgpt.com/codex/tasks/task_b_68967216dedc8330bafb6e1351ca52a9