### PR TITLE
Add first-run setup and package installation flow

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,12 +1,73 @@
-import React from 'react';
-import { Page, PageSection, Title } from '@patternfly/react-core';
+import React, { useEffect, useState } from 'react';
+import { Page, PageSection, Title, Button, Spinner, Alert } from '@patternfly/react-core';
+import backend from './backend';
 
-const App: React.FC = () => (
-  <Page>
-    <PageSection>
-      <Title headingLevel="h1">Cockpit WireGuard</Title>
-    </PageSection>
-  </Page>
-);
+const App: React.FC = () => {
+  const [loading, setLoading] = useState(true);
+  const [needsSetup, setNeedsSetup] = useState(false);
+  const [installing, setInstalling] = useState(false);
+  const [summary, setSummary] = useState<string | null>(null);
+
+  useEffect(() => {
+    backend
+      .checkPrereqs()
+      .then((res) => {
+        const ok = res.kernel && res.tools && res.systemd;
+        setNeedsSetup(!ok);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  const handleInstall = () => {
+    setInstalling(true);
+    setSummary(null);
+    backend
+      .installPackages()
+      .then(() => {
+        setSummary('Installation complete');
+        setInstalling(false);
+      })
+      .catch((err) => {
+        setSummary(`Installation failed: ${err}`);
+        setInstalling(false);
+      });
+  };
+
+  if (loading) {
+    return (
+      <Page>
+        <PageSection>
+          <Spinner />
+        </PageSection>
+      </Page>
+    );
+  }
+
+  if (needsSetup) {
+    return (
+      <Page>
+        <PageSection>
+          <Title headingLevel="h1">WireGuard setup</Title>
+          <p>WireGuard is not installed. Install WireGuard and enable systemd service templates.</p>
+          <Button variant="primary" onClick={handleInstall} isDisabled={installing}>
+            {installing ? 'Installing…' : 'Install WireGuard'}
+          </Button>
+          {summary && (
+            <Alert isInline variant="info" title={summary} />
+          )}
+        </PageSection>
+      </Page>
+    );
+  }
+
+  return (
+    <Page>
+      <PageSection>
+        <Title headingLevel="h1">Cockpit WireGuard</Title>
+      </PageSection>
+    </Page>
+  );
+};
 
 export default App;

--- a/ui/src/backend.ts
+++ b/ui/src/backend.ts
@@ -1,0 +1,34 @@
+declare const cockpit: any;
+
+class Backend {
+  private channel = cockpit.channel({ payload: 'json', path: 'wg-bridge', superuser: 'require' });
+  private seq = 0;
+
+  private call(method: string, params: any = {}): Promise<any> {
+    const id = String(this.seq++);
+    return new Promise((resolve, reject) => {
+      const handler = (_event: any, data: any) => {
+        if (data.id === id) {
+          this.channel.removeEventListener('message', handler);
+          if (data.error) {
+            reject(data.error);
+          } else {
+            resolve(data.result);
+          }
+        }
+      };
+      this.channel.addEventListener('message', handler);
+      this.channel.send({ jsonrpc: '2.0', id, method, params });
+    });
+  }
+
+  checkPrereqs(): Promise<any> {
+    return this.call('CheckPrereqs');
+  }
+
+  installPackages(): Promise<any> {
+    return this.call('InstallPackages');
+  }
+}
+
+export default new Backend();


### PR DESCRIPTION
## Summary
- detect OS package manager and check WireGuard prerequisites in backend
- add JSON-RPC methods for package install and prereq checks
- implement frontend first-run setup with install option

## Testing
- `npm --prefix ui run build`
- `cd bridge && go build -v`


------
https://chatgpt.com/codex/tasks/task_b_68967666adfc8330a8b92dc01a7b1df1