### PR TITLE
Add diagnostics self-test page

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -3,12 +3,14 @@ import { Page, PageSection, Title, Button, Spinner, Alert } from '@patternfly/re
 import backend from './backend';
 import Peers from './Peers';
 import InterfaceControls from './InterfaceControls';
+import Diagnostics from './Diagnostics';
 
 const App: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [needsSetup, setNeedsSetup] = useState(false);
   const [installing, setInstalling] = useState(false);
   const [summary, setSummary] = useState<string | null>(null);
+  const [page, setPage] = useState<'main' | 'diagnostics'>('main');
 
   useEffect(() => {
     backend
@@ -67,8 +69,16 @@ const App: React.FC = () => {
     <Page>
       <PageSection>
         <Title headingLevel="h1">Cockpit WireGuard</Title>
-        <InterfaceControls />
-        <Peers />
+        <Button variant="link" onClick={() => setPage('main')}>Interfaces</Button>
+        <Button variant="link" onClick={() => setPage('diagnostics')}>Diagnostics</Button>
+        {page === 'main' ? (
+          <>
+            <InterfaceControls />
+            <Peers />
+          </>
+        ) : (
+          <Diagnostics />
+        )}
       </PageSection>
     </Page>
   );

--- a/ui/src/Diagnostics.tsx
+++ b/ui/src/Diagnostics.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { PageSection, Title, Button, Spinner } from '@patternfly/react-core';
+import backend from './backend';
+
+const Diagnostics: React.FC = () => {
+  const [running, setRunning] = useState(false);
+  const [report, setReport] = useState('');
+  const [details, setDetails] = useState<any>(null);
+
+  const handleRun = () => {
+    setRunning(true);
+    setReport('');
+    setDetails(null);
+    backend
+      .runSelfTest()
+      .then((res) => {
+        setReport(res.report);
+        setDetails(res.details);
+      })
+      .catch((err) => {
+        setReport(`Error: ${err}`);
+      })
+      .finally(() => setRunning(false));
+  };
+
+  return (
+    <PageSection>
+      <Title headingLevel="h1">Diagnostics</Title>
+      <Button onClick={handleRun} isDisabled={running}>
+        {running ? 'Running…' : 'Run self-test'}
+      </Button>
+      {running && <Spinner />}
+      {report && <pre>{report}</pre>}
+      {details && <pre>{JSON.stringify(details, null, 2)}</pre>}
+    </PageSection>
+  );
+};
+
+export default Diagnostics;

--- a/ui/src/backend.ts
+++ b/ui/src/backend.ts
@@ -30,6 +30,10 @@ class Backend {
     return this.call('InstallPackages');
   }
 
+  runSelfTest(): Promise<any> {
+    return this.call('RunSelfTest');
+  }
+
   listInterfaces(): Promise<any> {
     return this.call('ListInterfaces');
   }


### PR DESCRIPTION
## Summary
- add backend self-test covering WireGuard prerequisites and runtime checks
- expose self-test API to frontend
- new Diagnostics page with one-click self-test report

## Testing
- `go test ./...` (from `bridge`)
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6896862998dc8330997f823dc9282437