### PR TITLE
Add structured navigation and improve forms

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,16 +1,33 @@
 import React, { useEffect, useState } from 'react';
-import { Page, PageSection, Title, Button, Spinner, Alert } from '@patternfly/react-core';
+import {
+  Page,
+  PageSection,
+  Title,
+  Button,
+  Spinner,
+  Alert,
+  Nav,
+  NavList,
+  NavItem,
+  PageSidebar,
+  PageSidebarBody
+} from '@patternfly/react-core';
 import backend from './backend';
 import Peers from './Peers';
 import InterfaceControls from './InterfaceControls';
 import Diagnostics from './Diagnostics';
+import Overview from './Overview';
+import Traffic from './Traffic';
+import Exchange from './Exchange';
 
 const App: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [needsSetup, setNeedsSetup] = useState(false);
   const [installing, setInstalling] = useState(false);
   const [summary, setSummary] = useState<string | null>(null);
-  const [page, setPage] = useState<'main' | 'diagnostics'>('main');
+  const [page, setPage] = useState<
+    'overview' | 'interfaces' | 'peers' | 'traffic' | 'diagnostics' | 'exchange'
+  >('overview');
 
   useEffect(() => {
     backend
@@ -65,21 +82,45 @@ const App: React.FC = () => {
     );
   }
 
+  const nav = (
+    <Nav onSelect={(e, itemId) => setPage(itemId as any)} aria-label="Primary navigation">
+      <NavList>
+        <NavItem itemId="overview" isActive={page === 'overview'}>
+          Overview
+        </NavItem>
+        <NavItem itemId="interfaces" isActive={page === 'interfaces'}>
+          Interfaces
+        </NavItem>
+        <NavItem itemId="peers" isActive={page === 'peers'}>
+          Peers
+        </NavItem>
+        <NavItem itemId="traffic" isActive={page === 'traffic'}>
+          Traffic
+        </NavItem>
+        <NavItem itemId="diagnostics" isActive={page === 'diagnostics'}>
+          Diagnostics
+        </NavItem>
+        <NavItem itemId="exchange" isActive={page === 'exchange'}>
+          Exchange
+        </NavItem>
+      </NavList>
+    </Nav>
+  );
+
+  const sidebar = (
+    <PageSidebar>
+      <PageSidebarBody>{nav}</PageSidebarBody>
+    </PageSidebar>
+  );
+
   return (
-    <Page>
-      <PageSection>
-        <Title headingLevel="h1">Cockpit WireGuard</Title>
-        <Button variant="link" onClick={() => setPage('main')}>Interfaces</Button>
-        <Button variant="link" onClick={() => setPage('diagnostics')}>Diagnostics</Button>
-        {page === 'main' ? (
-          <>
-            <InterfaceControls />
-            <Peers />
-          </>
-        ) : (
-          <Diagnostics />
-        )}
-      </PageSection>
+    <Page sidebar={sidebar} isManagedSidebar>
+      {page === 'overview' && <Overview />}
+      {page === 'interfaces' && <InterfaceControls />}
+      {page === 'peers' && <Peers />}
+      {page === 'traffic' && <Traffic />}
+      {page === 'diagnostics' && <Diagnostics />}
+      {page === 'exchange' && <Exchange />}
     </Page>
   );
 };

--- a/ui/src/Exchange.tsx
+++ b/ui/src/Exchange.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import {
+  PageSection,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader
+} from '@patternfly/react-core';
+
+const Exchange: React.FC = () => (
+  <PageSection>
+    <EmptyState variant="sm">
+      <EmptyStateHeader titleText="Exchange" headingLevel="h1" />
+      <EmptyStateBody>No exchange data available.</EmptyStateBody>
+    </EmptyState>
+  </PageSection>
+);
+
+export default Exchange;

--- a/ui/src/InterfaceControls.tsx
+++ b/ui/src/InterfaceControls.tsx
@@ -1,5 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Alert, FormGroup } from '@patternfly/react-core';
+import {
+  Button,
+  Alert,
+  FormGroup,
+  Modal,
+  PageSection,
+  Title
+} from '@patternfly/react-core';
 import backend from './backend';
 import MetricsGraph from './MetricsGraph';
 
@@ -10,6 +17,7 @@ const InterfaceControls: React.FC = () => {
   const [lastChange, setLastChange] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
+  const [confirmDown, setConfirmDown] = useState(false);
   const [metrics, setMetrics] = useState<{ timestamps: number[]; rx: number[]; tx: number[] }>({
     timestamps: [],
     rx: [],
@@ -76,11 +84,22 @@ const InterfaceControls: React.FC = () => {
     p.catch((e) => setError(String(e))).finally(scheduleRefresh);
   };
 
+  const confirmDownAction = () => {
+    setConfirmDown(false);
+    doAction('down')();
+  };
+
   return (
-    <div>
+    <PageSection>
+      <Title headingLevel="h1">Interfaces</Title>
       {error && <Alert isInline variant="danger" title={error} />}
-      <FormGroup label="Interface" fieldId="iface-select">
-        <select id="iface-select" value={selected} onChange={(e) => setSelected(e.target.value)}>
+      <FormGroup label="Interface" fieldId="iface-select" helperText="Select the interface to manage">
+        <select
+          id="iface-select"
+          value={selected}
+          onChange={(e) => setSelected(e.target.value)}
+          aria-label="Interface selector"
+        >
           {interfaces.map((n) => (
             <option key={n} value={n}>
               {n}
@@ -95,13 +114,28 @@ const InterfaceControls: React.FC = () => {
       <Button variant="primary" onClick={doAction('up')} isDisabled={!selected}>
         Up
       </Button>{' '}
-      <Button variant="secondary" onClick={doAction('down')} isDisabled={!selected}>
+      <Button variant="secondary" onClick={() => setConfirmDown(true)} isDisabled={!selected}>
         Down
       </Button>{' '}
       <Button variant="secondary" onClick={doAction('restart')} isDisabled={!selected}>
         Restart
       </Button>
-    </div>
+      <Modal
+        title="Bring interface down?"
+        isOpen={confirmDown}
+        onClose={() => setConfirmDown(false)}
+        actions={[
+          <Button key="confirm" variant="danger" onClick={confirmDownAction}>
+            Down
+          </Button>,
+          <Button key="cancel" variant="secondary" onClick={() => setConfirmDown(false)}>
+            Cancel
+          </Button>,
+        ]}
+      >
+        Bringing the interface down will disconnect all peers.
+      </Modal>
+    </PageSection>
   );
 };
 

--- a/ui/src/Overview.tsx
+++ b/ui/src/Overview.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { PageSection, Title, Skeleton } from '@patternfly/react-core';
+
+const Overview: React.FC = () => (
+  <PageSection>
+    <Title headingLevel="h1">Overview</Title>
+    <Skeleton width="50%" />
+    <Skeleton width="70%" />
+  </PageSection>
+);
+
+export default Overview;

--- a/ui/src/Peers.tsx
+++ b/ui/src/Peers.tsx
@@ -1,5 +1,23 @@
 import React, { useState } from 'react';
-import { Form, FormGroup, TextInput, Checkbox, Button, Alert } from '@patternfly/react-core';
+import {
+  Form,
+  FormGroup,
+  TextInput,
+  Checkbox,
+  Button,
+  Alert,
+  Tooltip,
+  PageSection,
+  Title,
+  SearchInput,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader
+} from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import QRCode from 'qrcode';
 import backend from './backend';
 
@@ -11,6 +29,7 @@ const Peers: React.FC = () => {
   const [enabled, setEnabled] = useState(true);
   const [publicKey, setPublicKey] = useState<string | null>(null);
   const [qr, setQr] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
 
   const handleAdd = async () => {
     const peer = {
@@ -39,29 +58,101 @@ const Peers: React.FC = () => {
     }
   };
 
+  const handleCancel = () => {
+    setEndpoint('');
+    setAllowedIPs('');
+    setKeepalive('');
+    setPreshared(false);
+    setEnabled(true);
+    setPublicKey(null);
+    setQr(null);
+  };
+
   return (
-    <div>
+    <PageSection>
+      <Title headingLevel="h1">Peers</Title>
       <Form>
-        <FormGroup label="Endpoint" fieldId="endpoint">
-          <TextInput id="endpoint" value={endpoint} onChange={(_, v) => setEndpoint(v)} />
+        <FormGroup label="Endpoint" fieldId="endpoint" helperText="Peer's endpoint in host:port format">
+          <TextInput
+            id="endpoint"
+            value={endpoint}
+            onChange={(_, v) => setEndpoint(v)}
+            aria-label="Endpoint"
+          />
         </FormGroup>
-        <FormGroup label="AllowedIPs" fieldId="allowed">
-          <TextInput id="allowed" value={allowedIPs} onChange={(_, v) => setAllowedIPs(v)} />
+        <FormGroup label="Allowed IPs" fieldId="allowed" helperText="Comma-separated list of allowed IPs">
+          <TextInput
+            id="allowed"
+            value={allowedIPs}
+            onChange={(_, v) => setAllowedIPs(v)}
+            aria-label="Allowed IPs"
+          />
         </FormGroup>
-        <FormGroup label="PersistentKeepalive" fieldId="keepalive">
-          <TextInput id="keepalive" value={keepalive} onChange={(_, v) => setKeepalive(v)} />
+        <FormGroup
+          label="Persistent keepalive"
+          fieldId="keepalive"
+          helperText="Seconds between keepalive packets"
+          labelIcon={
+            <Tooltip content="Advanced: helps maintain NAT mappings">
+              <InfoCircleIcon />
+            </Tooltip>
+          }
+        >
+          <TextInput
+            id="keepalive"
+            value={keepalive}
+            onChange={(_, v) => setKeepalive(v)}
+            aria-label="Persistent keepalive"
+          />
         </FormGroup>
-        <FormGroup label="PresharedKey" fieldId="psk">
-          <Checkbox id="psk" isChecked={preshared} onChange={(_, v) => setPreshared(v)} label="Generate preshared key" />
+        <FormGroup
+          label="Preshared key"
+          fieldId="psk"
+          helperText="Generate an optional preshared key"
+          labelIcon={
+            <Tooltip content="Advanced: adds symmetric encryption">
+              <InfoCircleIcon />
+            </Tooltip>
+          }
+        >
+          <Checkbox
+            id="psk"
+            isChecked={preshared}
+            onChange={(_, v) => setPreshared(v)}
+            label="Generate preshared key"
+            aria-label="Preshared key"
+          />
         </FormGroup>
-        <FormGroup label="Enabled" fieldId="enabled">
-          <Checkbox id="enabled" isChecked={enabled} onChange={(_, v) => setEnabled(v)} label="Peer enabled" />
+        <FormGroup label="Enabled" fieldId="enabled" helperText="Peer is enabled">
+          <Checkbox
+            id="enabled"
+            isChecked={enabled}
+            onChange={(_, v) => setEnabled(v)}
+            label="Peer enabled"
+            aria-label="Peer enabled"
+          />
         </FormGroup>
-        <Button variant="primary" onClick={handleAdd}>Add peer</Button>
+        <Button variant="primary" onClick={handleAdd}>Add peer</Button>{' '}
+        <Button variant="secondary" onClick={handleCancel}>Cancel</Button>
       </Form>
       {publicKey && <Alert isInline variant="info" title={`Public key: ${publicKey}`} />}
       {qr && <img src={qr} alt="peer qr" />}
-    </div>
+      <Toolbar>
+        <ToolbarContent>
+          <ToolbarItem>
+            <SearchInput
+              aria-label="Search peers"
+              value={search}
+              onChange={(_, v) => setSearch(v)}
+            />
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
+      <EmptyState variant="sm">
+        <EmptyStateHeader titleText="No peers" headingLevel="h2" />
+        <EmptyStateBody>Add a peer to get started.</EmptyStateBody>
+      </EmptyState>
+    </PageSection>
   );
 };
 

--- a/ui/src/Traffic.tsx
+++ b/ui/src/Traffic.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import {
+  PageSection,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader
+} from '@patternfly/react-core';
+
+const Traffic: React.FC = () => (
+  <PageSection>
+    <EmptyState variant="sm">
+      <EmptyStateHeader titleText="Traffic" headingLevel="h1" />
+      <EmptyStateBody>No traffic data available.</EmptyStateBody>
+    </EmptyState>
+  </PageSection>
+);
+
+export default Traffic;


### PR DESCRIPTION
## Summary
- add left sidebar navigation with sections
- improve peers form with helper text, tooltips and search
- confirm interface down actions and add placeholder pages

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689709446a6c8330a703a058564a3282