### PR TITLE
feat: add i18n scaffolding and accessibility

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "@patternfly/react-core": "^5.0.0",
+        "i18next": "^25.3.2",
         "qrcode": "^1.5.1",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-i18next": "^15.6.1"
       },
       "devDependencies": {
         "@types/react": "^18.0.0",
@@ -267,6 +269,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1477,6 +1488,46 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.3.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.3.2.tgz",
+      "integrity": "sha512-JSnbZDxRVbphc5jiptxr3o2zocy5dEqpVm9qCGdJwRNO+9saUJS0/u4LnM/13C23fUEWxAylPqKU/NpMV/IjqA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -1754,6 +1805,32 @@
         "react": ">= 16.8 || 18.0.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.6.1.tgz",
+      "integrity": "sha512-uGrzSsOUUe2sDBG/+FJq2J1MM+Y4368/QW8OLEKSFvnDflHBbZhSd1u3UkW0Z06rMhZmnB/AQrhCpYfE5/5XNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -1902,7 +1979,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -2001,6 +2078,15 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which-module": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,15 +9,17 @@
   },
   "dependencies": {
     "@patternfly/react-core": "^5.0.0",
+    "i18next": "^25.3.2",
+    "qrcode": "^1.5.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "qrcode": "^1.5.1"
+    "react-i18next": "^15.6.1"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
     "typescript": "^5.0.0",
-    "vite": "^5.0.0",
-    "@vitejs/plugin-react": "^4.0.0"
+    "vite": "^5.0.0"
   }
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Page,
   PageSection,
@@ -21,6 +22,7 @@ import Traffic from './Traffic';
 import Exchange from './Exchange';
 
 const App: React.FC = () => {
+  const { t } = useTranslation();
   const [loading, setLoading] = useState(true);
   const [needsSetup, setNeedsSetup] = useState(false);
   const [installing, setInstalling] = useState(false);
@@ -46,11 +48,11 @@ const App: React.FC = () => {
     backend
       .installPackages()
       .then(() => {
-        setSummary('Installation complete');
+        setSummary(t('installationComplete'));
         setInstalling(false);
       })
       .catch((err) => {
-        setSummary(`Installation failed: ${err}`);
+        setSummary(t('installationFailed', { error: err }));
         setInstalling(false);
       });
   };
@@ -69,13 +71,13 @@ const App: React.FC = () => {
     return (
       <Page>
         <PageSection>
-          <Title headingLevel="h1">WireGuard setup</Title>
-          <p>WireGuard is not installed. Install WireGuard and enable systemd service templates.</p>
+          <Title headingLevel="h1">{t('wireguardSetup')}</Title>
+          <p>{t('wireguardNotInstalled')}</p>
           <Button variant="primary" onClick={handleInstall} isDisabled={installing}>
-            {installing ? 'Installing…' : 'Install WireGuard'}
+            {installing ? t('installing') : t('installWireGuard')}
           </Button>
           {summary && (
-            <Alert isInline variant="info" title={summary} />
+            <Alert isInline variant="info" title={summary} isLiveRegion />
           )}
         </PageSection>
       </Page>
@@ -83,25 +85,25 @@ const App: React.FC = () => {
   }
 
   const nav = (
-    <Nav onSelect={(e, itemId) => setPage(itemId as any)} aria-label="Primary navigation">
+    <Nav onSelect={(e, itemId) => setPage(itemId as any)} aria-label={t('nav.primary')}>
       <NavList>
         <NavItem itemId="overview" isActive={page === 'overview'}>
-          Overview
+          {t('nav.overview')}
         </NavItem>
         <NavItem itemId="interfaces" isActive={page === 'interfaces'}>
-          Interfaces
+          {t('nav.interfaces')}
         </NavItem>
         <NavItem itemId="peers" isActive={page === 'peers'}>
-          Peers
+          {t('nav.peers')}
         </NavItem>
         <NavItem itemId="traffic" isActive={page === 'traffic'}>
-          Traffic
+          {t('nav.traffic')}
         </NavItem>
         <NavItem itemId="diagnostics" isActive={page === 'diagnostics'}>
-          Diagnostics
+          {t('nav.diagnostics')}
         </NavItem>
         <NavItem itemId="exchange" isActive={page === 'exchange'}>
-          Exchange
+          {t('nav.exchange')}
         </NavItem>
       </NavList>
     </Nav>

--- a/ui/src/Diagnostics.tsx
+++ b/ui/src/Diagnostics.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import { PageSection, Title, Button, Spinner } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
 import backend from './backend';
 
 const Diagnostics: React.FC = () => {
+  const { t } = useTranslation();
   const [running, setRunning] = useState(false);
   const [report, setReport] = useState('');
   const [details, setDetails] = useState<any>(null);
@@ -18,16 +20,16 @@ const Diagnostics: React.FC = () => {
         setDetails(res.details);
       })
       .catch((err) => {
-        setReport(`Error: ${err}`);
+        setReport(t('diagnostics.error', { error: err }));
       })
       .finally(() => setRunning(false));
   };
 
   return (
     <PageSection>
-      <Title headingLevel="h1">Diagnostics</Title>
+      <Title headingLevel="h1">{t('diagnostics.title')}</Title>
       <Button onClick={handleRun} isDisabled={running}>
-        {running ? 'Running…' : 'Run self-test'}
+        {running ? t('diagnostics.running') : t('diagnostics.runSelfTest')}
       </Button>
       {running && <Spinner />}
       {report && <pre>{report}</pre>}

--- a/ui/src/Exchange.tsx
+++ b/ui/src/Exchange.tsx
@@ -5,14 +5,18 @@ import {
   EmptyStateBody,
   EmptyStateHeader
 } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
 
-const Exchange: React.FC = () => (
-  <PageSection>
-    <EmptyState variant="sm">
-      <EmptyStateHeader titleText="Exchange" headingLevel="h1" />
-      <EmptyStateBody>No exchange data available.</EmptyStateBody>
-    </EmptyState>
-  </PageSection>
-);
+const Exchange: React.FC = () => {
+  const { t } = useTranslation();
+  return (
+    <PageSection>
+      <EmptyState variant="sm">
+        <EmptyStateHeader titleText={t('exchange.title')} headingLevel="h1" />
+        <EmptyStateBody>{t('exchange.noData')}</EmptyStateBody>
+      </EmptyState>
+    </PageSection>
+  );
+};
 
 export default Exchange;

--- a/ui/src/InterfaceControls.tsx
+++ b/ui/src/InterfaceControls.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Button,
   Alert,
@@ -11,6 +12,7 @@ import backend from './backend';
 import MetricsGraph from './MetricsGraph';
 
 const InterfaceControls: React.FC = () => {
+  const { t } = useTranslation();
   const [interfaces, setInterfaces] = useState<string[]>([]);
   const [selected, setSelected] = useState<string>('');
   const [status, setStatus] = useState('');
@@ -91,14 +93,14 @@ const InterfaceControls: React.FC = () => {
 
   return (
     <PageSection>
-      <Title headingLevel="h1">Interfaces</Title>
-      {error && <Alert isInline variant="danger" title={error} />}
-      <FormGroup label="Interface" fieldId="iface-select" helperText="Select the interface to manage">
+      <Title headingLevel="h1">{t('interfaces.title')}</Title>
+      {error && <Alert isInline variant="danger" title={error} isLiveRegion />}
+      <FormGroup label={t('interfaces.interfaceLabel')} fieldId="iface-select" helperText={t('interfaces.interfaceHelp')}>
         <select
           id="iface-select"
           value={selected}
           onChange={(e) => setSelected(e.target.value)}
-          aria-label="Interface selector"
+          aria-label={t('interfaces.selectorAria')}
         >
           {interfaces.map((n) => (
             <option key={n} value={n}>
@@ -107,33 +109,33 @@ const InterfaceControls: React.FC = () => {
           ))}
         </select>
       </FormGroup>
-      <p>Status: {status}</p>
-      <p>Last change: {lastChange}</p>
+      <p>{t('interfaces.status', { status })}</p>
+      <p>{t('interfaces.lastChange', { lastChange })}</p>
       {message && <pre>{message}</pre>}
       <MetricsGraph times={metrics.timestamps} rx={metrics.rx} tx={metrics.tx} />
       <Button variant="primary" onClick={doAction('up')} isDisabled={!selected}>
-        Up
+        {t('interfaces.up')}
       </Button>{' '}
       <Button variant="secondary" onClick={() => setConfirmDown(true)} isDisabled={!selected}>
-        Down
+        {t('interfaces.down')}
       </Button>{' '}
       <Button variant="secondary" onClick={doAction('restart')} isDisabled={!selected}>
-        Restart
+        {t('interfaces.restart')}
       </Button>
       <Modal
-        title="Bring interface down?"
+        title={t('interfaces.bringDownTitle')}
         isOpen={confirmDown}
         onClose={() => setConfirmDown(false)}
         actions={[
           <Button key="confirm" variant="danger" onClick={confirmDownAction}>
-            Down
+            {t('interfaces.downConfirm')}
           </Button>,
           <Button key="cancel" variant="secondary" onClick={() => setConfirmDown(false)}>
-            Cancel
+            {t('interfaces.cancel')}
           </Button>,
         ]}
       >
-        Bringing the interface down will disconnect all peers.
+        {t('interfaces.modalBody')}
       </Modal>
     </PageSection>
   );

--- a/ui/src/MetricsGraph.tsx
+++ b/ui/src/MetricsGraph.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface Props {
   times: number[];
@@ -7,8 +8,9 @@ interface Props {
 }
 
 const MetricsGraph: React.FC<Props> = ({ times, rx, tx }) => {
+  const { t } = useTranslation();
   if (times.length === 0) {
-    return <svg role="img" aria-label="No traffic data" />;
+    return <svg role="img" aria-label={t('metrics.noData')} />;
   }
   const width = 400;
   const height = 100;
@@ -36,19 +38,22 @@ const MetricsGraph: React.FC<Props> = ({ times, rx, tx }) => {
       viewBox={`0 0 ${width} ${height}`}
       role="img"
       aria-labelledby="traffic-title"
+      aria-describedby="traffic-desc"
     >
-      <title id="traffic-title">Interface traffic (bytes per second)</title>
+      <title id="traffic-title">{t('metrics.title')}</title>
+      <desc id="traffic-desc">{t('metrics.desc')}</desc>
       <path
         d={rxPath}
         fill="none"
-        stroke="var(--pf-v5-global--palette--green-400)"
+        stroke="var(--pf-v5-global--palette--green-500)"
         strokeWidth="2"
       />
       <path
         d={txPath}
         fill="none"
-        stroke="var(--pf-v5-global--palette--blue-400)"
+        stroke="var(--pf-v5-global--palette--blue-500)"
         strokeWidth="2"
+        strokeDasharray="4"
       />
     </svg>
   );

--- a/ui/src/Overview.tsx
+++ b/ui/src/Overview.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import { PageSection, Title, Skeleton } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
 
-const Overview: React.FC = () => (
-  <PageSection>
-    <Title headingLevel="h1">Overview</Title>
-    <Skeleton width="50%" />
-    <Skeleton width="70%" />
-  </PageSection>
-);
+const Overview: React.FC = () => {
+  const { t } = useTranslation();
+  return (
+    <PageSection>
+      <Title headingLevel="h1">{t('overview.title')}</Title>
+      <Skeleton width="50%" />
+      <Skeleton width="70%" />
+    </PageSection>
+  );
+};
 
 export default Overview;

--- a/ui/src/Peers.tsx
+++ b/ui/src/Peers.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Form,
   FormGroup,
@@ -22,6 +23,7 @@ import QRCode from 'qrcode';
 import backend from './backend';
 
 const Peers: React.FC = () => {
+  const { t } = useTranslation();
   const [endpoint, setEndpoint] = useState('');
   const [allowedIPs, setAllowedIPs] = useState('');
   const [keepalive, setKeepalive] = useState('');
@@ -70,31 +72,31 @@ const Peers: React.FC = () => {
 
   return (
     <PageSection>
-      <Title headingLevel="h1">Peers</Title>
+      <Title headingLevel="h1">{t('peers.title')}</Title>
       <Form>
-        <FormGroup label="Endpoint" fieldId="endpoint" helperText="Peer's endpoint in host:port format">
+        <FormGroup label={t('peers.endpoint')} fieldId="endpoint" helperText={t('peers.endpointHelp')}>
           <TextInput
             id="endpoint"
             value={endpoint}
             onChange={(_, v) => setEndpoint(v)}
-            aria-label="Endpoint"
+            aria-label={t('peers.endpoint')}
           />
         </FormGroup>
-        <FormGroup label="Allowed IPs" fieldId="allowed" helperText="Comma-separated list of allowed IPs">
+        <FormGroup label={t('peers.allowedIps')} fieldId="allowed" helperText={t('peers.allowedIpsHelp')}>
           <TextInput
             id="allowed"
             value={allowedIPs}
             onChange={(_, v) => setAllowedIPs(v)}
-            aria-label="Allowed IPs"
+            aria-label={t('peers.allowedIps')}
           />
         </FormGroup>
         <FormGroup
-          label="Persistent keepalive"
+          label={t('peers.persistentKeepalive')}
           fieldId="keepalive"
-          helperText="Seconds between keepalive packets"
+          helperText={t('peers.keepaliveHelp')}
           labelIcon={
-            <Tooltip content="Advanced: helps maintain NAT mappings">
-              <InfoCircleIcon />
+            <Tooltip content={t('peers.keepaliveAdvanced')}>
+              <InfoCircleIcon aria-label={t('peers.moreInfo')} />
             </Tooltip>
           }
         >
@@ -102,16 +104,16 @@ const Peers: React.FC = () => {
             id="keepalive"
             value={keepalive}
             onChange={(_, v) => setKeepalive(v)}
-            aria-label="Persistent keepalive"
+            aria-label={t('peers.persistentKeepalive')}
           />
         </FormGroup>
         <FormGroup
-          label="Preshared key"
+          label={t('peers.presharedKey')}
           fieldId="psk"
-          helperText="Generate an optional preshared key"
+          helperText={t('peers.presharedHelp')}
           labelIcon={
-            <Tooltip content="Advanced: adds symmetric encryption">
-              <InfoCircleIcon />
+            <Tooltip content={t('peers.presharedAdvanced')}>
+              <InfoCircleIcon aria-label={t('peers.moreInfo')} />
             </Tooltip>
           }
         >
@@ -119,29 +121,29 @@ const Peers: React.FC = () => {
             id="psk"
             isChecked={preshared}
             onChange={(_, v) => setPreshared(v)}
-            label="Generate preshared key"
-            aria-label="Preshared key"
+            label={t('peers.generatePreshared')}
+            aria-label={t('peers.presharedKey')}
           />
         </FormGroup>
-        <FormGroup label="Enabled" fieldId="enabled" helperText="Peer is enabled">
+        <FormGroup label={t('peers.enabled')} fieldId="enabled" helperText={t('peers.peerEnabled')}>
           <Checkbox
             id="enabled"
             isChecked={enabled}
             onChange={(_, v) => setEnabled(v)}
-            label="Peer enabled"
-            aria-label="Peer enabled"
+            label={t('peers.peerEnabled')}
+            aria-label={t('peers.peerEnabled')}
           />
         </FormGroup>
-        <Button variant="primary" onClick={handleAdd}>Add peer</Button>{' '}
-        <Button variant="secondary" onClick={handleCancel}>Cancel</Button>
+        <Button variant="primary" onClick={handleAdd}>{t('peers.addPeer')}</Button>{' '}
+        <Button variant="secondary" onClick={handleCancel}>{t('peers.cancel')}</Button>
       </Form>
-      {publicKey && <Alert isInline variant="info" title={`Public key: ${publicKey}`} />}
-      {qr && <img src={qr} alt="peer qr" />}
+      {publicKey && <Alert isInline variant="info" title={t('peers.publicKey', { publicKey })} isLiveRegion />}
+      {qr && <img src={qr} alt={t('peers.peerQrAlt')} />}
       <Toolbar>
         <ToolbarContent>
           <ToolbarItem>
             <SearchInput
-              aria-label="Search peers"
+              aria-label={t('peers.searchPeers')}
               value={search}
               onChange={(_, v) => setSearch(v)}
             />
@@ -149,8 +151,8 @@ const Peers: React.FC = () => {
         </ToolbarContent>
       </Toolbar>
       <EmptyState variant="sm">
-        <EmptyStateHeader titleText="No peers" headingLevel="h2" />
-        <EmptyStateBody>Add a peer to get started.</EmptyStateBody>
+        <EmptyStateHeader titleText={t('peers.noPeers')} headingLevel="h2" />
+        <EmptyStateBody>{t('peers.addPeerToGetStarted')}</EmptyStateBody>
       </EmptyState>
     </PageSection>
   );

--- a/ui/src/Traffic.tsx
+++ b/ui/src/Traffic.tsx
@@ -5,14 +5,18 @@ import {
   EmptyStateBody,
   EmptyStateHeader
 } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
 
-const Traffic: React.FC = () => (
-  <PageSection>
-    <EmptyState variant="sm">
-      <EmptyStateHeader titleText="Traffic" headingLevel="h1" />
-      <EmptyStateBody>No traffic data available.</EmptyStateBody>
-    </EmptyState>
-  </PageSection>
-);
+const Traffic: React.FC = () => {
+  const { t } = useTranslation();
+  return (
+    <PageSection>
+      <EmptyState variant="sm">
+        <EmptyStateHeader titleText={t('traffic.title')} headingLevel="h1" />
+        <EmptyStateBody>{t('traffic.noData')}</EmptyStateBody>
+      </EmptyState>
+    </PageSection>
+  );
+};
 
 export default Traffic;

--- a/ui/src/accessibility.css
+++ b/ui/src/accessibility.css
@@ -1,0 +1,9 @@
+:focus-visible {
+  outline: 3px solid #000;
+  outline-offset: 2px;
+}
+@media (prefers-color-scheme: dark) {
+  :focus-visible {
+    outline: 3px solid #fff;
+  }
+}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1,0 +1,78 @@
+{
+  "wireguardSetup": "WireGuard setup",
+  "wireguardNotInstalled": "WireGuard is not installed. Install WireGuard and enable systemd service templates.",
+  "installing": "Installing…",
+  "installWireGuard": "Install WireGuard",
+  "installationComplete": "Installation complete",
+  "installationFailed": "Installation failed: {{error}}",
+  "nav": {
+    "overview": "Overview",
+    "interfaces": "Interfaces",
+    "peers": "Peers",
+    "traffic": "Traffic",
+    "diagnostics": "Diagnostics",
+    "exchange": "Exchange",
+    "primary": "Primary navigation"
+  },
+  "interfaces": {
+    "title": "Interfaces",
+    "interfaceLabel": "Interface",
+    "interfaceHelp": "Select the interface to manage",
+    "status": "Status: {{status}}",
+    "lastChange": "Last change: {{lastChange}}",
+    "up": "Up",
+    "down": "Down",
+    "restart": "Restart",
+    "bringDownTitle": "Bring interface down?",
+    "modalBody": "Bringing the interface down will disconnect all peers.",
+    "downConfirm": "Down",
+    "cancel": "Cancel",
+    "selectorAria": "Interface selector"
+  },
+  "diagnostics": {
+    "title": "Diagnostics",
+    "running": "Running…",
+    "runSelfTest": "Run self-test",
+    "error": "Error: {{error}}"
+  },
+  "peers": {
+    "title": "Peers",
+    "endpoint": "Endpoint",
+    "endpointHelp": "Peer's endpoint in host:port format",
+    "allowedIps": "Allowed IPs",
+    "allowedIpsHelp": "Comma-separated list of allowed IPs",
+    "persistentKeepalive": "Persistent keepalive",
+    "keepaliveHelp": "Seconds between keepalive packets",
+    "keepaliveAdvanced": "Advanced: helps maintain NAT mappings",
+    "presharedKey": "Preshared key",
+    "presharedHelp": "Generate an optional preshared key",
+    "presharedAdvanced": "Advanced: adds symmetric encryption",
+    "generatePreshared": "Generate preshared key",
+    "enabled": "Enabled",
+    "peerEnabled": "Peer enabled",
+    "addPeer": "Add peer",
+    "cancel": "Cancel",
+    "publicKey": "Public key: {{publicKey}}",
+    "peerQrAlt": "Peer QR code",
+    "searchPeers": "Search peers",
+    "noPeers": "No peers",
+    "addPeerToGetStarted": "Add a peer to get started.",
+    "moreInfo": "More information"
+  },
+  "overview": {
+    "title": "Overview"
+  },
+  "traffic": {
+    "title": "Traffic",
+    "noData": "No traffic data available."
+  },
+  "exchange": {
+    "title": "Exchange",
+    "noData": "No exchange data available."
+  },
+  "metrics": {
+    "noData": "No traffic data",
+    "title": "Interface traffic (bytes per second)",
+    "desc": "Solid green line shows received traffic; dashed blue line shows transmitted traffic."
+  }
+}

--- a/ui/src/i18n/index.ts
+++ b/ui/src/i18n/index.ts
@@ -1,0 +1,14 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from './en.json';
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources: { en: { translation: en } },
+    lng: 'en',
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false },
+  });
+
+export default i18n;

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom/client';
 import '@patternfly/react-core/dist/styles/base.css';
 import './preloadFonts';
 import './theme';
+import './i18n';
+import './accessibility.css';
 import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(


### PR DESCRIPTION
## Summary
- set up i18next scaffolding and wrap UI strings
- add high-contrast focus outline and screen-reader friendly alerts
- improve icon alternatives and graph ARIA labeling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68970a99dadc8330b298f8bdee51e592