### PR TITLE
feat: add node key management

### DIFF
--- a/bridge/exchange.go
+++ b/bridge/exchange.go
@@ -18,10 +18,9 @@ import (
 )
 
 const (
-	inboxDir        = "/var/lib/cockpit-wg/inbox"
-	trustedPubKey   = "/var/lib/cockpit-wg/signing.pub"
-	exchangePrivKey = "/var/lib/cockpit-wg/exchange.key"
-	pendingDir      = "/var/lib/cockpit-wg/pending"
+	inboxDir      = "/var/lib/cockpit-wg/inbox"
+	trustedPubKey = "/var/lib/cockpit-wg/signing.pub"
+	pendingDir    = "/var/lib/cockpit-wg/pending"
 )
 
 type Manifest struct {

--- a/bridge/keys.go
+++ b/bridge/keys.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	keyDir          = "/etc/cockpit-wg/keys"
+	exchangePrivKey = keyDir + "/exchange.key"
+	exchangePubKey  = keyDir + "/exchange.pub"
+	signingPrivKey  = keyDir + "/signing.key"
+	signingPubKey   = keyDir + "/signing.pub"
+)
+
+func ensureKeys() {
+	if err := os.MkdirAll(keyDir, 0700); err != nil {
+		auditLog("EnsureKeys", json.RawMessage(fmt.Sprintf("{\"error\":\"%v\"}", err)), err)
+		return
+	}
+	generated := false
+	if _, err := os.Stat(exchangePrivKey); os.IsNotExist(err) {
+		if err := exec.Command("age-keygen", "-o", exchangePrivKey).Run(); err == nil {
+			os.Chmod(exchangePrivKey, 0600)
+			os.Chown(exchangePrivKey, 0, 0)
+			cmd := exec.Command("age-keygen", "-y", exchangePrivKey)
+			if out, err := cmd.Output(); err == nil {
+				os.WriteFile(exchangePubKey, out, 0600)
+				os.Chown(exchangePubKey, 0, 0)
+			}
+			generated = true
+		}
+	}
+	if _, err := os.Stat(signingPrivKey); os.IsNotExist(err) {
+		if err := exec.Command("minisign", "-G", "-s", signingPrivKey, "-p", signingPubKey, "-n").Run(); err == nil {
+			os.Chmod(signingPrivKey, 0600)
+			os.Chown(signingPrivKey, 0, 0)
+			os.Chmod(signingPubKey, 0600)
+			os.Chown(signingPubKey, 0, 0)
+			generated = true
+		}
+	}
+	if generated {
+		auditLog("GenerateKeys", json.RawMessage("{}"), nil)
+	}
+}
+
+func getExchangeKey() (string, error) {
+	b, err := os.ReadFile(exchangePubKey)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+func rotateKeys() (string, error) {
+	ts := time.Now().Format("20060102150405")
+	for _, f := range []string{exchangePrivKey, exchangePubKey, signingPrivKey, signingPubKey} {
+		if _, err := os.Stat(f); err == nil {
+			os.Rename(f, f+"."+ts)
+		}
+	}
+	oldPriv := exchangePrivKey + "." + ts
+	if err := exec.Command("age-keygen", "-o", exchangePrivKey).Run(); err != nil {
+		return "", err
+	}
+	os.Chmod(exchangePrivKey, 0600)
+	os.Chown(exchangePrivKey, 0, 0)
+	pubOut, err := exec.Command("age-keygen", "-y", exchangePrivKey).Output()
+	if err != nil {
+		return "", err
+	}
+	os.WriteFile(exchangePubKey, pubOut, 0600)
+	os.Chown(exchangePubKey, 0, 0)
+	if err := exec.Command("minisign", "-G", "-s", signingPrivKey, "-p", signingPubKey, "-n").Run(); err != nil {
+		return "", err
+	}
+	os.Chmod(signingPrivKey, 0600)
+	os.Chown(signingPrivKey, 0, 0)
+	os.Chmod(signingPubKey, 0600)
+	os.Chown(signingPubKey, 0, 0)
+	reencryptInbox(oldPriv, strings.TrimSpace(string(pubOut)))
+	auditLog("RotateKeys", json.RawMessage(fmt.Sprintf("{\"timestamp\":\"%s\"}", ts)), nil)
+	return strings.TrimSpace(string(pubOut)), nil
+}
+
+func reencryptInbox(oldPriv, newPub string) {
+	entries, err := os.ReadDir(inboxDir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".wgx") {
+			continue
+		}
+		path := filepath.Join(inboxDir, e.Name())
+		tmp := path + ".tmp"
+		dec := exec.Command("age", "-d", "-i", oldPriv, "-o", tmp, path)
+		if err := dec.Run(); err != nil {
+			os.Remove(tmp)
+			continue
+		}
+		enc := exec.Command("age", "-r", newPub, "-o", path, tmp)
+		enc.Run()
+		os.Remove(tmp)
+	}
+}

--- a/bridge/main.go
+++ b/bridge/main.go
@@ -46,6 +46,7 @@ type respError struct {
 }
 
 func main() {
+	ensureKeys()
 	initMetricsCollector()
 	go watchInbox()
 	scanner := bufio.NewScanner(os.Stdin)
@@ -181,6 +182,10 @@ func handleRequest(req *request) *response {
 		if err = json.Unmarshal(req.Params, &p); err == nil {
 			result, err = listPeers(p.Name)
 		}
+	case "GetExchangeKey":
+		result, err = getExchangeKey()
+	case "RotateKeys":
+		result, err = rotateKeys()
 	default:
 		err = errors.New("unknown method")
 	}

--- a/ui/src/Exchange.tsx
+++ b/ui/src/Exchange.tsx
@@ -1,20 +1,55 @@
-import React from 'react';
+import React, { useEffect, useState } from "react";
 import {
   PageSection,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateHeader
-} from '@patternfly/react-core';
-import { useTranslation } from 'react-i18next';
+  Title,
+  Button,
+  Alert,
+  AlertGroup,
+} from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
+import backend from "./backend";
+import QRCode from "qrcode";
 
 const Exchange: React.FC = () => {
   const { t } = useTranslation();
+  const [key, setKey] = useState("");
+  const [qr, setQr] = useState<string | null>(null);
+  const [warn, setWarn] = useState(false);
+
+  const loadKey = async () => {
+    const k = await backend.getExchangeKey();
+    setKey(k);
+    const data = await QRCode.toDataURL(k);
+    setQr(data);
+  };
+
+  useEffect(() => {
+    loadKey();
+  }, []);
+
+  const rotate = async () => {
+    await backend.rotateKeys();
+    await loadKey();
+    setWarn(true);
+  };
+
   return (
     <PageSection>
-      <EmptyState variant="sm">
-        <EmptyStateHeader titleText={t('exchange.title')} headingLevel="h1" />
-        <EmptyStateBody>{t('exchange.noData')}</EmptyStateBody>
-      </EmptyState>
+      {warn && (
+        <AlertGroup>
+          <Alert
+            variant="warning"
+            title={t("exchange.redistributeWarning")}
+            isInline
+          />
+        </AlertGroup>
+      )}
+      <Title headingLevel="h1">{t("exchange.title")}</Title>
+      <p>
+        {t("exchange.pubKeyLabel")}: {key}
+      </p>
+      {qr && <img src={qr} alt={t("exchange.pubKeyLabel")} />}
+      <Button onClick={rotate}>{t("exchange.rotate")}</Button>
     </PageSection>
   );
 };

--- a/ui/src/backend.ts
+++ b/ui/src/backend.ts
@@ -1,7 +1,11 @@
 declare const cockpit: any;
 
 class Backend {
-  private channel = cockpit.channel({ payload: 'json', path: 'wg-bridge', superuser: 'require' });
+  private channel = cockpit.channel({
+    payload: "json",
+    path: "wg-bridge",
+    superuser: "require",
+  });
   private seq = 0;
 
   private call(method: string, params: any = {}): Promise<any> {
@@ -9,7 +13,7 @@ class Backend {
     return new Promise((resolve, reject) => {
       const handler = (_event: any, data: any) => {
         if (data.id === id) {
-          this.channel.removeEventListener('message', handler);
+          this.channel.removeEventListener("message", handler);
           if (data.error) {
             reject(data.error);
           } else {
@@ -17,61 +21,69 @@ class Backend {
           }
         }
       };
-      this.channel.addEventListener('message', handler);
-      this.channel.send({ jsonrpc: '2.0', id, method, params });
+      this.channel.addEventListener("message", handler);
+      this.channel.send({ jsonrpc: "2.0", id, method, params });
     });
   }
 
   checkPrereqs(): Promise<any> {
-    return this.call('CheckPrereqs');
+    return this.call("CheckPrereqs");
   }
 
   installPackages(): Promise<any> {
-    return this.call('InstallPackages');
+    return this.call("InstallPackages");
   }
 
   runSelfTest(): Promise<any> {
-    return this.call('RunSelfTest');
+    return this.call("RunSelfTest");
   }
 
   listInterfaces(): Promise<any> {
-    return this.call('ListInterfaces');
+    return this.call("ListInterfaces");
   }
 
   getInterfaceStatus(name: string): Promise<any> {
-    return this.call('GetInterfaceStatus', { name });
+    return this.call("GetInterfaceStatus", { name });
   }
 
   upInterface(name: string): Promise<any> {
-    return this.call('UpInterface', { name });
+    return this.call("UpInterface", { name });
   }
 
   downInterface(name: string): Promise<any> {
-    return this.call('DownInterface', { name });
+    return this.call("DownInterface", { name });
   }
 
   restartInterface(name: string): Promise<any> {
-    return this.call('RestartInterface', { name });
+    return this.call("RestartInterface", { name });
   }
 
   getMetrics(name: string): Promise<any> {
-    return this.call('GetMetrics', { name });
+    return this.call("GetMetrics", { name });
   }
 
   addPeer(name: string, peer: any): Promise<any> {
-    return this.call('AddPeer', { name, peer });
+    return this.call("AddPeer", { name, peer });
   }
 
   listPeers(name: string): Promise<any> {
-    return this.call('ListPeers', { name });
+    return this.call("ListPeers", { name });
   }
 
   removePeer(name: string, publicKey: string): Promise<any> {
-    return this.call('RemovePeer', { name, publicKey });
+    return this.call("RemovePeer", { name, publicKey });
   }
 
   updatePeer(name: string, publicKey: string, peer: any): Promise<any> {
-    return this.call('UpdatePeer', { name, publicKey, peer });
+    return this.call("UpdatePeer", { name, publicKey, peer });
+  }
+
+  getExchangeKey(): Promise<any> {
+    return this.call("GetExchangeKey");
+  }
+
+  rotateKeys(): Promise<any> {
+    return this.call("RotateKeys");
   }
 }
 

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -68,7 +68,10 @@
   },
   "exchange": {
     "title": "Exchange",
-    "noData": "No exchange data available."
+    "noData": "No exchange data available.",
+    "pubKeyLabel": "Public exchange key",
+    "rotate": "Rotate keys",
+    "redistributeWarning": "Redistribute the new public key to peers."
   },
   "metrics": {
     "noData": "No traffic data",


### PR DESCRIPTION
## Summary
- generate and rotate exchange/signing keys
- expose exchange public key and rotation UI

## Testing
- `go build`
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_b_6897102f365c8330974e1ce09561f80b