### PR TITLE
Add export and inbox audit flows

### DIFF
--- a/bridge/exchange.go
+++ b/bridge/exchange.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/coreos/go-systemd/v22/journal"
 	"github.com/fsnotify/fsnotify"
@@ -149,4 +150,104 @@ func unpackBundle(tarPath string) (*Manifest, []byte, map[string][]byte, error) 
 		return nil, nil, nil, fmt.Errorf("incomplete bundle")
 	}
 	return &manifest, cfg, meta, nil
+}
+
+// exportBundle creates an encrypted and signed bundle for the given interface
+// and returns the path to the generated .wgx file. The recipient parameter
+// expects the target node's public exchange key.
+func exportBundle(iface, recipient string) (string, error) {
+	cfgPath := filepath.Join("/etc/wireguard", iface+".conf")
+	cfg, err := os.ReadFile(cfgPath)
+	if err != nil {
+		auditExchange("export", iface, "", err)
+		return "", err
+	}
+	sum := sha256.Sum256(cfg)
+	manifest := Manifest{Interface: iface, Version: 1, Checksum: hex.EncodeToString(sum[:])}
+	tmp, err := os.CreateTemp("", iface+"-*.tar")
+	if err != nil {
+		auditExchange("export", iface, hex.EncodeToString(sum[:]), err)
+		return "", err
+	}
+	defer os.Remove(tmp.Name())
+	tw := tar.NewWriter(tmp)
+	manBytes, _ := json.Marshal(manifest)
+	tw.WriteHeader(&tar.Header{Name: "manifest.json", Mode: 0600, Size: int64(len(manBytes))})
+	tw.Write(manBytes)
+	tw.WriteHeader(&tar.Header{Name: "config.conf", Mode: 0600, Size: int64(len(cfg))})
+	tw.Write(cfg)
+	tw.Close()
+	tmp.Close()
+	outName := filepath.Join(os.TempDir(), fmt.Sprintf("%s-%d.wgx", iface, time.Now().UnixNano()))
+	enc := exec.Command("age", "-r", recipient, "-o", outName, tmp.Name())
+	if err := enc.Run(); err != nil {
+		auditExchange("export", iface, hex.EncodeToString(sum[:]), err)
+		os.Remove(outName)
+		return "", err
+	}
+	sign := exec.Command("minisign", "-Sm", outName, "-s", signingPrivKey)
+	if err := sign.Run(); err != nil {
+		auditExchange("export", iface, hex.EncodeToString(sum[:]), err)
+		os.Remove(outName)
+		return "", err
+	}
+	auditExchange("export", iface, hex.EncodeToString(sum[:]), nil)
+	return outName, nil
+}
+
+// listInboxBundles enumerates .wgx files in the inbox directory and returns a
+// slice with basic verification results for each bundle.
+func listInboxBundles() ([]map[string]interface{}, error) {
+	entries, err := os.ReadDir(inboxDir)
+	if err != nil {
+		return nil, err
+	}
+	result := []map[string]interface{}{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".wgx") {
+			continue
+		}
+		path := filepath.Join(inboxDir, e.Name())
+		info := map[string]interface{}{"file": e.Name()}
+		sig := path + ".minisig"
+		if _, err := os.Stat(sig); err == nil {
+			cmd := exec.Command("minisign", "-Vm", path, "-x", sig, "-P", trustedPubKey)
+			if cmd.Run() == nil {
+				info["signature"] = true
+			} else {
+				info["signature"] = false
+			}
+		} else {
+			info["signature"] = false
+		}
+		decPath := path + ".tar"
+		cmd := exec.Command("age", "-d", "-i", exchangePrivKey, "-o", decPath, path)
+		if cmd.Run() == nil {
+			info["recipient"] = true
+			man, cfg, _, err := unpackBundle(decPath)
+			if err == nil {
+				sum := sha256.Sum256(cfg)
+				info["checksum"] = strings.EqualFold(man.Checksum, hex.EncodeToString(sum[:]))
+				info["interface"] = man.Interface
+			} else {
+				info["checksum"] = false
+			}
+		} else {
+			info["recipient"] = false
+		}
+		os.Remove(decPath)
+		result = append(result, info)
+	}
+	return result, nil
+}
+
+func auditExchange(action, iface, hash string, err error) {
+	actor := os.Getenv("USER")
+	fp, _ := getSigningFingerprint()
+	fields := map[string]interface{}{"action": action, "actor": actor, "iface": iface, "hash": hash, "signing_fp": fp}
+	if err != nil {
+		fields["error"] = err.Error()
+	}
+	msgBytes, _ := json.Marshal(fields)
+	journal.Send(string(msgBytes), journal.PriInfo, nil)
 }

--- a/bridge/keys.go
+++ b/bridge/keys.go
@@ -110,3 +110,11 @@ func reencryptInbox(oldPriv, newPub string) {
 		os.Remove(tmp)
 	}
 }
+
+func getSigningFingerprint() (string, error) {
+	out, err := exec.Command("minisign", "-F", "-p", signingPubKey).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/bridge/main.go
+++ b/bridge/main.go
@@ -186,6 +186,20 @@ func handleRequest(req *request) *response {
 		result, err = getExchangeKey()
 	case "RotateKeys":
 		result, err = rotateKeys()
+	case "ExportConfig":
+		var p struct {
+			Name      string `json:"name"`
+			Recipient string `json:"recipient"`
+		}
+		if err = json.Unmarshal(req.Params, &p); err == nil {
+			var path string
+			path, err = exportBundle(p.Name, p.Recipient)
+			if err == nil {
+				result = map[string]string{"path": path, "signature": path + ".minisig"}
+			}
+		}
+	case "ListInbox":
+		result, err = listInboxBundles()
 	default:
 		err = errors.New("unknown method")
 	}


### PR DESCRIPTION
## Summary
- add backend function to export WireGuard configs to encrypted, signed bundles
- allow listing inbox bundles with verification status and audit logs
- expose new JSON-RPC methods for export and inbox listing

## Testing
- `go build`
- `npm --prefix ui run build`


------
https://chatgpt.com/codex/tasks/task_b_689711c8cdac8330bd72c6e6373db60e