### PR TITLE
Add Ansible role for cockpit-wg deployment

### DIFF
--- a/ansible/roles/cockpit-wg/defaults/main.yml
+++ b/ansible/roles/cockpit-wg/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+# Default variables for cockpit-wg role
+
+cockpit_wg_src_dir: "{{ role_path }}/../../dist/cockpit-wg"
+cockpit_wg_plugin_dir: /usr/share/cockpit/cockpit-wg
+cockpit_wg_polkit_dir: /usr/share/polkit-1/rules.d
+cockpit_wg_wireguard_dir: /etc/wireguard
+cockpit_wg_keys_dir: /etc/cockpit-wg/keys
+cockpit_wg_inbox_dir: /var/lib/cockpit-wg/inbox
+
+cockpit_wg_seed_inventory: false
+cockpit_wg_inventory_path: "{{ playbook_dir }}/exchange-keys"
+
+cockpit_wg_polkit_service_map:
+  Debian: polkit
+  RedHat: polkit
+cockpit_wg_polkit_service: "{{ cockpit_wg_polkit_service_map[ansible_os_family] | default('polkit') }}"
+
+cockpit_wg_admin_group_map:
+  Debian: sudo
+  RedHat: wheel
+cockpit_wg_admin_group: "{{ cockpit_wg_admin_group_map[ansible_os_family] | default('wheel') }}"

--- a/ansible/roles/cockpit-wg/handlers/main.yml
+++ b/ansible/roles/cockpit-wg/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+# Handlers for cockpit-wg role
+
+- name: Reload polkit
+  service:
+    name: "{{ cockpit_wg_polkit_service }}"
+    state: reloaded
+
+- name: Reload systemd
+  systemd:
+    daemon_reload: true

--- a/ansible/roles/cockpit-wg/tasks/main.yml
+++ b/ansible/roles/cockpit-wg/tasks/main.yml
@@ -1,7 +1,64 @@
 ---
-# Placeholder tasks for deploying cockpit-wg
-- name: Ensure wg-bridge binary is installed
-  copy:
-    src: wg-bridge
-    dest: /usr/local/bin/wg-bridge
+# Tasks for deploying cockpit-wg plugin and bridge
+
+- name: Ensure plugin directory exists
+  file:
+    path: "{{ cockpit_wg_plugin_dir }}"
+    state: directory
+    owner: root
+    group: root
     mode: '0755'
+
+- name: Install cockpit-wg plugin files
+  copy:
+    src: "{{ cockpit_wg_src_dir }}/"
+    dest: "{{ cockpit_wg_plugin_dir }}/"
+    mode: '0644'
+  notify: Reload systemd
+
+- name: Install wg-bridge binary
+  copy:
+    src: "{{ cockpit_wg_src_dir }}/wg-bridge"
+    dest: "{{ cockpit_wg_plugin_dir }}/wg-bridge"
+    mode: '0755'
+  notify: Reload systemd
+
+- name: Install polkit rules for cockpit-wg
+  template:
+    src: cockpit-wg.rules.j2
+    dest: "{{ cockpit_wg_polkit_dir }}/50-cockpit-wg.rules"
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Reload polkit
+
+- name: Ensure WireGuard directory exists
+  file:
+    path: "{{ cockpit_wg_wireguard_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Ensure cockpit-wg key directory exists
+  file:
+    path: "{{ cockpit_wg_keys_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0700'
+
+- name: Ensure cockpit-wg inbox directory exists
+  file:
+    path: "{{ cockpit_wg_inbox_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0700'
+
+- name: Seed public exchange key into inventory
+  fetch:
+    src: "{{ cockpit_wg_keys_dir }}/public.key"
+    dest: "{{ cockpit_wg_inventory_path }}/{{ inventory_hostname }}.pub"
+    flat: true
+  when: cockpit_wg_seed_inventory

--- a/ansible/roles/cockpit-wg/templates/cockpit-wg.rules.j2
+++ b/ansible/roles/cockpit-wg/templates/cockpit-wg.rules.j2
@@ -1,0 +1,6 @@
+polkit.addRule(function(action, subject) {
+  if (action.id == "org.cockpit-project.cockpit-wg.spawn" &&
+      subject.active && subject.isInGroup("{{ cockpit_wg_admin_group }}")) {
+    return polkit.Result.AUTH_ADMIN_KEEP;
+  }
+});


### PR DESCRIPTION
## Summary
- deploy cockpit-wg plugin and bridge via Ansible role
- add defaults for distro families and reload handlers for polkit/systemd

## Testing
- `npm --prefix ui run build`
- `go test ./...` (within `bridge` module)


------
https://chatgpt.com/codex/tasks/task_b_6897133497bc8330af2cada269e88774