### PR TITLE
Add CI scanning and packaging workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release Packages
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ github.ref_name }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache-dependency-path: bridge/go.sum
+
+      - name: Build frontend
+        run: |
+          cd ui
+          npm ci
+          npm run build
+
+      - name: Build backend
+        run: |
+          cd bridge
+          go build -ldflags "-s -w -X main.version=${VERSION}" -o wg-bridge
+
+      - name: Prepare package files
+        run: |
+          mkdir -p package/usr/share/cockpit/cockpit-wg
+          cp ui/manifest.json package/usr/share/cockpit/cockpit-wg/
+          cp ui/dist/index.html package/usr/share/cockpit/cockpit-wg/
+          cp -r ui/dist/assets package/usr/share/cockpit/cockpit-wg/
+          cp bridge/wg-bridge package/usr/share/cockpit/cockpit-wg/wg-bridge
+          chmod +x package/usr/share/cockpit/cockpit-wg/wg-bridge
+
+      - name: Install packaging tools
+        run: |
+          curl -fsSL https://github.com/goreleaser/nfpm/releases/latest/download/nfpm_Linux_x86_64.tar.gz | tar -xz -C /usr/local/bin nfpm
+          sudo apt-get update && sudo apt-get install -y minisign
+
+      - name: Build packages
+        run: |
+          nfpm package --config packaging/nfpm.yaml --packager deb --target dist/cockpit-wg_${VERSION}.deb --version ${VERSION}
+          nfpm package --config packaging/nfpm.yaml --packager rpm --target dist/cockpit-wg_${VERSION}.rpm --version ${VERSION}
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum cockpit-wg_${VERSION}.deb cockpit-wg_${VERSION}.rpm > checksums.txt
+
+      - name: Sign assets
+        env:
+          MINISIGN_KEY: ${{ secrets.MINISIGN_KEY }}
+        run: |
+          printf '%s' "$MINISIGN_KEY" > minisign.key
+          minisign -Sm -s minisign.key dist/cockpit-wg_${VERSION}.deb
+          minisign -Sm -s minisign.key dist/cockpit-wg_${VERSION}.rpm
+          minisign -Sm -s minisign.key dist/checksums.txt
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/cockpit-wg_${VERSION}.deb
+            dist/cockpit-wg_${VERSION}.deb.minisig
+            dist/cockpit-wg_${VERSION}.rpm
+            dist/cockpit-wg_${VERSION}.rpm.minisig
+            dist/checksums.txt
+            dist/checksums.txt.minisig
+          draft: false
+          prerelease: ${{ contains(env.VERSION, 'rc') || contains(env.VERSION, 'beta') || contains(env.VERSION, 'alpha') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,15 +31,13 @@ jobs:
           cd ui
           npm test
 
-      - name: Lint TypeScript
+      - name: Run ESLint
         run: |
           cd ui
-          # Добавим линтер если его нет
           if [ -f "package.json" ] && grep -q "lint" package.json; then
             npm run lint
           else
-            echo "No linter configured, checking TypeScript compilation"
-            npx tsc --noEmit
+            npx eslint .
           fi
 
       - name: Build frontend
@@ -76,6 +74,11 @@ jobs:
           go-version: '1.22'
           cache-dependency-path: bridge/go.sum
 
+      - name: Build backend
+        run: |
+          cd bridge
+          go build ./...
+
       - name: Run tests
         run: |
           cd bridge
@@ -91,6 +94,12 @@ jobs:
         with:
           working-directory: bridge
           version: "2023.1.7"
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v5
+        with:
+          working-directory: bridge
+          version: latest
 
       - name: Check formatting
         run: |
@@ -151,3 +160,58 @@ jobs:
           go list -json -deps ./... | jq -r 'select(.Module != null) | .Module.Path' | sort -u > deps.txt
           echo "Go dependencies:"
           cat deps.txt
+
+  trivy-scan:
+    name: Container and License Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Trivy
+        uses: aquasecurity/trivy-action@v0.21.0
+        with:
+          scan-type: fs
+          scanners: vuln,license
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
+
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Generate Go SBOM
+        run: |
+          cd bridge
+          go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest
+          export PATH="$HOME/go/bin:$PATH"
+          cyclonedx-gomod mod -o ../bom-go.json
+
+      - name: Generate npm SBOM
+        run: |
+          cd ui
+          npm ci
+          npx @cyclonedx/cyclonedx-npm --output ../bom-npm.json
+
+      - name: Upload SBOMs
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: |
+            bom-go.json
+            bom-npm.json
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ make multi-arch
 - **Go 1.22+**
 - **Make** (optional)
 
+> These versions match the GitHub Actions environment (see `.github/workflows/test.yml` and `.github/workflows/release.yml`) and are required for building, linting, testing, and packaging.
+
 ### Local Development
 ```bash
 # Clone repository

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -28,6 +28,8 @@ This project automatically builds for multiple platforms using GitHub Actions:
 - **Go 1.22+**
 - **Make** (optional, for convenience)
 
+> The project uses these versions in `.github/workflows/test.yml` and `.github/workflows/release.yml`; install them locally for consistent building, linting, testing, and packaging.
+
 ### Quick Start
 ```bash
 # Build for current platform (Linux recommended)

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -1,0 +1,12 @@
+name: cockpit-wg
+arch: amd64
+platform: linux
+version: 0.0.0
+section: utils
+priority: optional
+maintainer: Cockpit WG Maintainers <devnull@example.com>
+description: Cockpit WireGuard Manager plugin
+license: MIT
+contents:
+  - src: package/usr/share/cockpit/cockpit-wg/**
+    dst: /usr/share/cockpit/cockpit-wg


### PR DESCRIPTION
## Summary
- run eslint, Go linters (go vet, staticcheck, golangci-lint) and npm audit
- add Trivy scan and generate CycloneDX SBOMs for Go and npm deps
- release packages (.deb/.rpm) with minisign signatures and checksums
- document Node.js 18+ and Go 1.22+ as required for local parity

## Testing
- `npm test --prefix ui`
- `go test -v ./...` (pass)


------
https://chatgpt.com/codex/tasks/task_b_68972711d8b48330894bb3ce60beade3