### PR TITLE
Add pprof profiling and document resource usage

### DIFF
--- a/bridge/pprof.go
+++ b/bridge/pprof.go
@@ -1,0 +1,17 @@
+//go:build pprof
+
+package main
+
+import (
+	"log"
+	"net/http"
+	_ "net/http/pprof"
+)
+
+func init() {
+	go func() {
+		if err := http.ListenAndServe("localhost:6060", nil); err != nil {
+			log.Printf("pprof server: %v", err)
+		}
+	}()
+}

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,3 +1,5 @@
 # Operations Guide
 
 Operational documentation.
+
+- [Resource usage](resource-usage.md)

--- a/docs/operations/resource-usage.md
+++ b/docs/operations/resource-usage.md
@@ -1,0 +1,19 @@
+# Resource Usage
+
+This project aims to minimize resource consumption while monitoring WireGuard interfaces.
+
+- Metrics sampling is timer-driven with a minimum interval of 2 seconds to avoid busy loops.
+- Ring buffers hold a bounded history, automatically discarding the oldest samples.
+- WireGuard state uses `wgctrl` instead of spawning external commands, except for `systemctl` or package-management tasks.
+- UI refreshes are debounced to roughly 500ms to prevent excessive updates.
+- Optional profiling is available by building with the `pprof` tag:
+  ```
+  go build -tags pprof
+  ```
+  A pprof server will listen on `localhost:6060` when enabled.
+
+Resource targets on typical systems:
+
+- Idle CPU usage near 0%
+- Metrics sampling below 1% CPU
+- Resident memory under 50MB

--- a/ui/src/InterfaceControls.tsx
+++ b/ui/src/InterfaceControls.tsx
@@ -1,30 +1,35 @@
-import React, { useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import React, { useEffect, useState, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import {
   Button,
   Alert,
   FormGroup,
   Modal,
   PageSection,
-  Title
-} from '@patternfly/react-core';
-import backend from './backend';
-import MetricsGraph from './MetricsGraph';
+  Title,
+} from "@patternfly/react-core";
+import backend from "./backend";
+import MetricsGraph from "./MetricsGraph";
 
 const InterfaceControls: React.FC = () => {
   const { t } = useTranslation();
   const [interfaces, setInterfaces] = useState<string[]>([]);
-  const [selected, setSelected] = useState<string>('');
-  const [status, setStatus] = useState('');
-  const [lastChange, setLastChange] = useState('');
-  const [message, setMessage] = useState('');
-  const [error, setError] = useState('');
+  const [selected, setSelected] = useState<string>("");
+  const [status, setStatus] = useState("");
+  const [lastChange, setLastChange] = useState("");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
   const [confirmDown, setConfirmDown] = useState(false);
-  const [metrics, setMetrics] = useState<{ timestamps: number[]; rx: number[]; tx: number[] }>({
+  const [metrics, setMetrics] = useState<{
+    timestamps: number[];
+    rx: number[];
+    tx: number[];
+  }>({
     timestamps: [],
     rx: [],
     tx: [],
   });
+  const refreshTimer = useRef<number>();
 
   useEffect(() => {
     backend
@@ -46,7 +51,7 @@ const InterfaceControls: React.FC = () => {
       .then((res) => {
         setStatus(res.status);
         setLastChange(res.last_change);
-        setMessage(res.message || '');
+        setMessage(res.message || "");
       })
       .catch((e) => setError(String(e)));
   };
@@ -72,35 +77,44 @@ const InterfaceControls: React.FC = () => {
   }, [selected]);
 
   const scheduleRefresh = () => {
-    refreshStatus();
-    const id = setInterval(refreshStatus, 2000);
-    setTimeout(() => clearInterval(id), 10000);
+    if (refreshTimer.current) {
+      clearTimeout(refreshTimer.current);
+    }
+    refreshTimer.current = window.setTimeout(() => {
+      refreshStatus();
+      const id = setInterval(refreshStatus, 2000);
+      setTimeout(() => clearInterval(id), 10000);
+    }, 500);
   };
 
-  const doAction = (action: 'up' | 'down' | 'restart') => () => {
-    setError('');
+  const doAction = (action: "up" | "down" | "restart") => () => {
+    setError("");
     let p: Promise<any>;
-    if (action === 'up') p = backend.upInterface(selected);
-    else if (action === 'down') p = backend.downInterface(selected);
+    if (action === "up") p = backend.upInterface(selected);
+    else if (action === "down") p = backend.downInterface(selected);
     else p = backend.restartInterface(selected);
     p.catch((e) => setError(String(e))).finally(scheduleRefresh);
   };
 
   const confirmDownAction = () => {
     setConfirmDown(false);
-    doAction('down')();
+    doAction("down")();
   };
 
   return (
     <PageSection>
-      <Title headingLevel="h1">{t('interfaces.title')}</Title>
+      <Title headingLevel="h1">{t("interfaces.title")}</Title>
       {error && <Alert isInline variant="danger" title={error} isLiveRegion />}
-      <FormGroup label={t('interfaces.interfaceLabel')} fieldId="iface-select" helperText={t('interfaces.interfaceHelp')}>
+      <FormGroup
+        label={t("interfaces.interfaceLabel")}
+        fieldId="iface-select"
+        helperText={t("interfaces.interfaceHelp")}
+      >
         <select
           id="iface-select"
           value={selected}
           onChange={(e) => setSelected(e.target.value)}
-          aria-label={t('interfaces.selectorAria')}
+          aria-label={t("interfaces.selectorAria")}
         >
           {interfaces.map((n) => (
             <option key={n} value={n}>
@@ -109,33 +123,49 @@ const InterfaceControls: React.FC = () => {
           ))}
         </select>
       </FormGroup>
-      <p>{t('interfaces.status', { status })}</p>
-      <p>{t('interfaces.lastChange', { lastChange })}</p>
+      <p>{t("interfaces.status", { status })}</p>
+      <p>{t("interfaces.lastChange", { lastChange })}</p>
       {message && <pre>{message}</pre>}
-      <MetricsGraph times={metrics.timestamps} rx={metrics.rx} tx={metrics.tx} />
-      <Button variant="primary" onClick={doAction('up')} isDisabled={!selected}>
-        {t('interfaces.up')}
-      </Button>{' '}
-      <Button variant="secondary" onClick={() => setConfirmDown(true)} isDisabled={!selected}>
-        {t('interfaces.down')}
-      </Button>{' '}
-      <Button variant="secondary" onClick={doAction('restart')} isDisabled={!selected}>
-        {t('interfaces.restart')}
+      <MetricsGraph
+        times={metrics.timestamps}
+        rx={metrics.rx}
+        tx={metrics.tx}
+      />
+      <Button variant="primary" onClick={doAction("up")} isDisabled={!selected}>
+        {t("interfaces.up")}
+      </Button>{" "}
+      <Button
+        variant="secondary"
+        onClick={() => setConfirmDown(true)}
+        isDisabled={!selected}
+      >
+        {t("interfaces.down")}
+      </Button>{" "}
+      <Button
+        variant="secondary"
+        onClick={doAction("restart")}
+        isDisabled={!selected}
+      >
+        {t("interfaces.restart")}
       </Button>
       <Modal
-        title={t('interfaces.bringDownTitle')}
+        title={t("interfaces.bringDownTitle")}
         isOpen={confirmDown}
         onClose={() => setConfirmDown(false)}
         actions={[
           <Button key="confirm" variant="danger" onClick={confirmDownAction}>
-            {t('interfaces.downConfirm')}
+            {t("interfaces.downConfirm")}
           </Button>,
-          <Button key="cancel" variant="secondary" onClick={() => setConfirmDown(false)}>
-            {t('interfaces.cancel')}
+          <Button
+            key="cancel"
+            variant="secondary"
+            onClick={() => setConfirmDown(false)}
+          >
+            {t("interfaces.cancel")}
           </Button>,
         ]}
       >
-        {t('interfaces.modalBody')}
+        {t("interfaces.modalBody")}
       </Modal>
     </PageSection>
   );


### PR DESCRIPTION
## Summary
- add optional pprof server behind `pprof` build tag
- debounce interface status refreshes to 500ms in UI
- document resource usage targets and profiling in operations guide

## Testing
- `make test` *(fails: FAIL wg-bridge/internal/validator)*

------
https://chatgpt.com/codex/tasks/task_b_689731ff02dc8330a0085a282910f8bf