### PR TITLE
feat(ui): add centralized design tokens

### DIFF
--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -4,6 +4,7 @@ import '@patternfly/react-core/dist/styles/base.css';
 import './preloadFonts';
 import './theme';
 import './i18n';
+import './tokens.css';
 import './accessibility.css';
 import App from './App';
 

--- a/ui/src/tokens.css
+++ b/ui/src/tokens.css
@@ -1,0 +1,27 @@
+/* Global design tokens for spacing, radius, shadows, and transitions */
+:root {
+  --space-0: 0;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 1rem;
+  --space-4: 1.5rem;
+  --space-5: 2rem;
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 16px;
+
+  --shadow-sm: 0 1px 2px rgb(0 0 0 / 0.05);
+  --shadow-md: 0 4px 6px rgb(0 0 0 / 0.1);
+  --shadow-lg: 0 10px 15px rgb(0 0 0 / 0.15);
+
+  --transition-fast: 150ms;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --shadow-sm: 0 1px 2px rgb(0 0 0 / 0.4);
+    --shadow-md: 0 4px 6px rgb(0 0 0 / 0.6);
+    --shadow-lg: 0 10px 15px rgb(0 0 0 / 0.8);
+  }
+}


### PR DESCRIPTION
## Summary
- centralize spacing, radius, shadow and transition tokens with dark-mode variants
- load token stylesheet in UI entry point

## Testing
- `npm test`
- `go test ./...` (fails: invalid PublicKey format)

------
https://chatgpt.com/codex/tasks/task_b_689735862f68833082e90d964e0dbc48