### PR TITLE
docs: add admin and operations guides

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -1,0 +1,51 @@
+# Admin Guide
+
+## Installation
+
+### Pre-built packages
+```bash
+# Download latest release for your architecture
+wget https://github.com/alphasigma1912/cockpit-wg/releases/latest/download/cockpit-wg-linux-amd64.tar.gz
+
+# Extract and install
+sudo tar -xzf cockpit-wg-linux-amd64.tar.gz -C /usr/share/cockpit/
+
+# Restart Cockpit to load the plugin
+sudo systemctl restart cockpit
+```
+
+### Build from source
+```bash
+# Assemble the plugin for the current platform
+make dist
+
+# Install the build
+sudo cp -r dist/cockpit-wg/ /usr/share/cockpit/
+sudo systemctl restart cockpit
+```
+
+## First run
+1. Log in to Cockpit at `https://<host>:9090`.
+2. Open **Cockpit WireGuard Manager**.
+3. Authorize the Polkit prompt to allow package installation and key generation.
+4. The backend creates exchange/signing keys and installs WireGuard if missing.
+
+## Basic operations
+- **Create interface** – Use the *Add Interface* form, then click **Apply Changes**.
+- **Add peer** – Select an interface, open *Peers*, and use **Add Peer**.
+- **Start/stop interface** – Use the toggle in the interface list.
+- **Export config** – Click **Export** to produce a `.wgx` bundle.
+- **Import config** – Drop a `.wgx` bundle on the interface list or use *Import Bundle*.
+
+### CLI examples
+```bash
+# List interfaces
+sudo /usr/share/cockpit/cockpit-wg/wg-bridge <<'RPC'
+{"jsonrpc":"2.0","id":1,"method":"ListInterfaces"}
+RPC
+
+# Bring an interface up
+sudo /usr/share/cockpit/cockpit-wg/wg-bridge <<'RPC'
+{"jsonrpc":"2.0","id":1,"method":"UpInterface","params":{"name":"wg0"}}
+RPC
+```

--- a/docs/exchange.md
+++ b/docs/exchange.md
@@ -1,0 +1,43 @@
+# Configuration Exchange
+
+## `.wgx` bundle format
+```
+bundle.wgx  (age-encrypted and minisign-signed)
+└── tar archive
+    ├── manifest.json   # {"interface","version","checksum"}
+    ├── config.conf     # WireGuard config
+    └── meta/           # optional metadata files
+```
+- `checksum` is the SHA-256 of `config.conf`
+- `version` starts at `1` and increments on updates
+
+## Key provisioning
+Exchange and signing keys live in `/etc/cockpit-wg/keys` and are created on first run.
+```bash
+# Retrieve this node's exchange public key
+echo '{"jsonrpc":"2.0","id":1,"method":"GetExchangeKey"}' \
+  | sudo /usr/share/cockpit/cockpit-wg/wg-bridge
+
+# Rotate all exchange and signing keys
+echo '{"jsonrpc":"2.0","id":1,"method":"RotateKeys"}' \
+  | sudo /usr/share/cockpit/cockpit-wg/wg-bridge
+```
+
+## Exporting
+```bash
+# Produce a bundle for interface wg0 encrypted to recipient's public key
+RECIPIENT="age1example..."
+echo '{"jsonrpc":"2.0","id":1,"method":"ExportConfig","params":{"iface":"wg0","recipient":"'"$RECIPIENT"'"}}' \
+  | sudo /usr/share/cockpit/cockpit-wg/wg-bridge
+# Output: path to generated .wgx and .wgx.minisig files
+```
+
+## Importing
+1. Place `<file>.wgx` and `<file>.wgx.minisig` into `/var/lib/cockpit-wg/inbox/`
+2. The daemon verifies signature, decrypts, and stages the config in `pending/`
+3. Apply the pending config through the UI or JSON-RPC
+```bash
+# List bundles detected in the inbox
+echo '{"jsonrpc":"2.0","id":1,"method":"ListInbox"}' \
+  | sudo /usr/share/cockpit/cockpit-wg/wg-bridge
+```

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,34 @@
+# Packaging
+
+## Prerequisites
+- [nfpm](https://nfpm.goreleaser.com/) installed (`go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest`)
+- `make` build tools
+
+## Build packages
+```bash
+# Assemble the plugin artifacts
+make dist
+
+# Set version used in nfpm.yaml
+export VERSION=$(git describe --tags --always --dirty)
+
+# Build .deb package
+nfpm package --config packaging/nfpm.yaml --packager deb \
+  --target dist/cockpit-wg_${VERSION}_amd64.deb
+
+# Build .rpm package
+nfpm package --config packaging/nfpm.yaml --packager rpm \
+  --target dist/cockpit-wg-${VERSION}-1.x86_64.rpm
+```
+
+## Install
+```bash
+# Debian/Ubuntu
+dpkg -i dist/cockpit-wg_${VERSION}_amd64.deb
+
+# RHEL/Fedora
+rpm -i dist/cockpit-wg-${VERSION}-1.x86_64.rpm
+
+# Reload Cockpit
+sudo systemctl restart cockpit
+```

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,18 @@
+# Security Overview
+
+## Threat model
+- Unprivileged users attempting to escalate via the web UI
+- Injection of shell arguments or malformed configs
+- Theft of WireGuard private keys
+- Tampering with configuration files on disk
+- Exfiltration of `.wgx` bundles in transit or at rest
+
+## Baseline controls
+- Backend runs with **least privilege** and gates privileged calls with **Polkit**
+- Only a small, explicit JSON-RPC API; **no arbitrary command execution**
+- Strict input validation and canonicalization on all requests
+- Frontend served with a **Content-Security-Policy** that forbids inline scripts
+- Private keys never leave the backend and are zeroized from memory
+- Sensitive files written with `umask 077` and **atomic writes** with rollback
+- Audit logs recorded for all privileged operations
+- Exchange inbox requires authenticated, **minisign-signed** bundles and verifies SHA-256 checksums

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,28 @@
+# Testing
+
+## Unit tests
+```bash
+# Run frontend and backend unit tests
+make test
+
+# Backend only
+cd bridge && go test ./...
+
+# Frontend only
+cd ui && npm test
+```
+
+## Integration tests
+`run_tests.sh` exercises the backend with coverage, fuzzing, race detection and benchmarks.
+```bash
+./run_tests.sh            # Linux/macOS
+# or
+pwsh run_tests.ps1        # Windows
+```
+
+## End-to-end (E2E) tests
+Requires a built UI (`make ui`) and a running Cockpit instance.
+```bash
+cd ui
+npm run e2e               # headless Cypress run
+```


### PR DESCRIPTION
## Summary
- add admin guide with installation, first run and basic operations
- document security model and controls
- cover .wgx exchange workflow, packaging, and test execution

## Testing
- `make test` *(fails: wg-bridge/internal/validator)*

------
https://chatgpt.com/codex/tasks/task_b_68973e9d7bac8330b05547d810e5e178